### PR TITLE
Update readme submodule

### DIFF
--- a/README
+++ b/README
@@ -18,8 +18,7 @@ Building
 
 in root directory:
 
-$ git submodule init
-$ git submodule update
+$ git submodule update --init --recursive
 
 enter lnsocket submodule and type:
 

--- a/README
+++ b/README
@@ -16,6 +16,11 @@ LNLink is powered by lnsocket, a C library I created to connect to the lightning
 Building
 --------
 
+in root directory:
+
+$ git submodule init
+$ git submodule update
+
 enter lnsocket submodule and type:
 
 $ make ios


### PR DESCRIPTION
Adding this step to the README. Still getting a build error for sodium though:

```
honk at Honk-Mac in ~/code/lnlink/lnsocket (heads/master)
$ make ios
cc lnsocket-x86_64.o
lnsocket.c:17:10: fatal error: 'sodium/crypto_aead_chacha20poly1305.h' file not found
#include <sodium/crypto_aead_chacha20poly1305.h>
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
make: *** [lnsocket-x86_64.o] Error 1
```