### PR TITLE
Change Type of withMemoryRebound to CChar

### DIFF
--- a/lightninglink/LNUrl.swift
+++ b/lightninglink/LNUrl.swift
@@ -59,7 +59,7 @@ func decode_bech32(_ str: String) -> Bech32? {
     var m_data: Data? = nil
     var typ: bech32_encoding = BECH32_ENCODING_NONE
 
-    hrp_buf.withMemoryRebound(to: UInt8.self) { hrp_ptr in
+    hrp_buf.withMemoryRebound(to: CChar.self) { hrp_ptr in
     str.withCString { input in
         typ = bech32_decode(hrp_ptr.baseAddress, bits_buf.baseAddress, &bitslen, input, str.count)
         bech32_convert_bits(data_buf.baseAddress, &datalen, 8, bits_buf.baseAddress, bitslen, 5, 0)


### PR DESCRIPTION
I was getting a build error here: 

```swift
Cannot convert value of type 'UnsafeMutablePointer<UInt8>?' to expected argument type 'UnsafeMutablePointer<CChar>?' (aka 'Optional<UnsafeMutablePointer<Int8>>')
```

on Xcode 13.2.1. Changing to `CChar` seems like what was expected. Could be something different about my environment though.